### PR TITLE
Update Agda-installation.md to fix compilation error on emacs mode

### DIFF
--- a/Agda/Agda-installation.md
+++ b/Agda/Agda-installation.md
@@ -34,7 +34,7 @@ Most people use emacs with agda-mode to edit, but you can also use neovim with
 cornelis or vscode with the agda-mode port.
 
 To get emacs with agda-mode set up, there's a [tutorial
-here](https://agda.readthedocs.io/en/v2.6.2.2/getting-started/installation.html#running-the-agda-mode-program)
+here](https://agda.readthedocs.io/en/v2.6.2.2/getting-started/installation.html#running-the-agda-mode-program); installing from `cabal` leads to a complaint that some comments in `agda-mode2.el` are wider than 80 characters.  In case you run into that comment, an edited version of the file is provided [here](agda-mode2.el), simply replace it.
 
 To get neovim with corenlis setup, there's installation instructions on [their
 GitHub](https://github.com/isovector/cornelis)


### PR DESCRIPTION
Added a comment about an installation issue I encountered installing from cabal (`ghc-9.2.5`); have not reproduced via other means,  but also provided the version of the offending emacs mode that I made to fix the problem.